### PR TITLE
Potential fix for code scanning alert no. 82: Uncontrolled data used in path expression

### DIFF
--- a/routes/keyServer.ts
+++ b/routes/keyServer.ts
@@ -4,17 +4,28 @@
  */
 
 import path = require('path')
+import fs = require('fs')
 import { type Request, type Response, type NextFunction } from 'express'
 
 module.exports = function serveKeyFiles () {
   return ({ params }: Request, res: Response, next: NextFunction) => {
     const file = params.file
 
-    if (!file.includes('/')) {
-      res.sendFile(path.resolve('encryptionkeys/', file))
+    const ROOT = path.resolve('encryptionkeys')
+    const requestedPath = path.resolve(ROOT, file)
+    let realPath
+    try {
+      realPath = fs.realpathSync(requestedPath)
+    } catch (e) {
+      res.status(404)
+      next(new Error('File not found!'))
+      return
+    }
+    if (realPath.startsWith(ROOT + path.sep)) {
+      res.sendFile(realPath)
     } else {
       res.status(403)
-      next(new Error('File names cannot contain forward slashes!'))
+      next(new Error('Access to the requested file is forbidden!'))
     }
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/s4yhii/juice-shop/security/code-scanning/82](https://github.com/s4yhii/juice-shop/security/code-scanning/82)

To fix the problem, we need to ensure that the file path constructed from user input is strictly contained within the intended directory (`encryptionkeys/`). The best way to do this is to resolve the path using `path.resolve`, then check that the resulting path starts with the absolute path of the intended directory. Additionally, we should use `path.join` to construct the path, and consider using `fs.realpathSync` to resolve any symbolic links. The check for forward slashes should be replaced or supplemented with this more robust validation. The changes should be made in `routes/keyServer.ts`, specifically in the function that serves key files (lines 13-18). We will also need to import `fs` to use `fs.realpathSync`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
